### PR TITLE
Create the CI pipeline

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,19 @@
+name: C/C++ CI
+
+# For a push or pull request on the main branch, run the following jobs.
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+# Build the repository on the latest version of Ubuntu, an OS not dissimilar to Raspbian.
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    # Check out the repository and run the makefile.
+    steps:
+    - uses: actions/checkout@v3
+    - name: make
+      run: make


### PR DESCRIPTION
Continuous integration is going to be handy for automatic building and testing. This currently builds whatever will be in the repository, but later edits will allow for testing. There's just nothing in yet to run or test.